### PR TITLE
utf8_enforcer_tag_with_tag_removed never getting called

### DIFF
--- a/lib/utf8_enforcer_workaround/action_view/helpers/form_tag_helper.rb
+++ b/lib/utf8_enforcer_workaround/action_view/helpers/form_tag_helper.rb
@@ -18,5 +18,5 @@ end
 
 ActionView::Helpers::FormTagHelper.class_eval do
   include Utf8EnforcerWorkaround::ActionView::Helpers::FormTagHelper
-  included { alias_method_chain :utf8_enforcer_tag, :tag_removed }
+  alias_method_chain :utf8_enforcer_tag, :tag_removed
 end


### PR DESCRIPTION
For some reason, when using this in my application, `utf8_enforcer_tag_with_tag_removed` was never getting called. 

I found that removing the `included` call in `ActionView::Helpers::FormTagHelper.class_eval` and instead just calling `alias_method_chain` directly fixed the problem.

Unfortunately I have not been able to come up with a test case for this.  Maybe it has something with using haml instead of erb in my application, but I don't know how to update the cucumber tests for utf8_enforcer_workaround to test against haml instead of erb.  I just know this fix works for me, and don't see any harm in it (and it doesn't break any existing tests).
