### PR TITLE
don't double-define VERSION

### DIFF
--- a/lib/utf8_enforcer_workaround/version.rb
+++ b/lib/utf8_enforcer_workaround/version.rb
@@ -1,3 +1,3 @@
 module Utf8EnforcerWorkaround
-  VERSION = "1.0.1"
+  VERSION = "1.0.1" unless defined? Utf8EnforcerWorkaround::VERSION
 end


### PR DESCRIPTION
I was getting warnings about this gem's VERSION constant already being defined.

This fix prevents that, by not attempting to redefine VERSION if it has already been defined.
